### PR TITLE
Fix record types (p_state, pf_state, faultcode)

### DIFF
--- a/src/soap.hrl
+++ b/src/soap.hrl
@@ -31,8 +31,8 @@
     in_type :: [{string(), atom()}]  | atom(), %% the list type is only used
                                                %% during construction of the 
                                                %% interface
-    out_type :: [{string(), atom()}] | undefined | atom(), %% see above
-    fault_types :: [atom()]}).
+    out_type :: [{string(), atom()}] | undefined | atom() %% see above
+}).
 -type op() :: #op{}.
 
 -record(interface, {

--- a/src/soap_fault.erl
+++ b/src/soap_fault.erl
@@ -76,12 +76,12 @@
     version :: atom(),
     state :: atom(),
     characters = "" :: string(),
-    code :: fault_code_object(),
-    fault_string :: fault_string(),
+    code :: fault_code_object() | undefined,
+    fault_string :: fault_string() | undefined,
     actor :: fault_actor(),
     reasons = [] :: [fault_reason()],
-    language :: string(),
-    detail_tag :: {tag(), uri()},
+    language :: string() | undefined,
+    detail_tag :: {tag(), uri()} | undefined,
     details = [] :: [{tag(), uri(), string()}]
 }).
 

--- a/src/soap_fault.hrl
+++ b/src/soap_fault.hrl
@@ -26,9 +26,9 @@
                       tag :: string(),
                       text :: string()}).
 
--record(faultcode, {uri :: string(),
+-record(faultcode, {uri :: string() | undefined,
                     code :: string() | atom(),
-                    subcode :: #faultcode{} % only v. 1.2
+                    subcode :: #faultcode{} | undefined % only v. 1.2
                    }).
 
 -record(faultreason, {text :: string(),


### PR DESCRIPTION
Upstream PR: https://github.com/bet365/soap/pull/52

Address post-OTP 19 requirement for explicit `undefined` see: https://www.erlang.org/doc/system/typespec.html#type-information-in-record-declarations